### PR TITLE
Add BLE scan UI on Android with Accompanist

### DIFF
--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -49,4 +49,5 @@ dependencies {
     implementation("androidx.activity:activity-compose")
     implementation("androidx.compose.material3:material3")
     implementation("net.java.dev.jna:jna:5.13.0")
+    implementation("com.google.accompanist:accompanist-permissions:0.37.3")
 }

--- a/platforms/android/app/src/main/AndroidManifest.xml
+++ b/platforms/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
 
     <application
         android:allowBackup="true"
-        android:label="Clipboard"
+        android:label="Nearclip"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar"
         android:supportsRtl="true">
         <activity android:name="com.mouse.nearclip.MainActivity" android:exported="true">

--- a/platforms/android/app/src/main/java/com/mouse/nearclip/MainActivity.kt
+++ b/platforms/android/app/src/main/java/com/mouse/nearclip/MainActivity.kt
@@ -2,12 +2,19 @@ package com.mouse.nearclip
 
 import android.Manifest
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
 import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanResult
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -15,14 +22,19 @@ import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.Card
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
 
@@ -31,7 +43,10 @@ class MainActivity : ComponentActivity() {
     private val TAG = "NearClip"
     private lateinit var bluetoothAdapter: BluetoothAdapter
     private var scanCallback: ScanCallback? = null
+    private var bluetoothGatt: BluetoothGatt? = null
     private val scannedDevices = mutableStateListOf<ScanResult>()
+    private val handler = Handler(Looper.getMainLooper())
+    private var scanning by mutableStateOf(false)
 
     @OptIn(ExperimentalPermissionsApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -57,17 +72,31 @@ class MainActivity : ComponentActivity() {
         Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
             Button(onClick = {
                 if (permissionState.allPermissionsGranted) {
-                    startBleScan()
+                    if (scanning) {
+                        stopBleScan()
+                    } else {
+                        startBleScan()
+                    }
                 } else {
                     permissionState.launchMultiplePermissionRequest()
                 }
             }) {
-                Text("Scan")
+                Text(if (scanning) "Scanning..." else "Scan")
             }
             LazyColumn(modifier = Modifier.padding(top = 16.dp)) {
-                items(scannedDevices) { result ->
+                items(scannedDevices, key = { it.device.address }) { result ->
                     val name = result.device.name ?: "Unknown"
-                    Text("$name - ${result.device.address}")
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp)
+                            .clickable { connectToDevice(result.device) }
+                    ) {
+                        Column(Modifier.padding(8.dp)) {
+                            Text(name, style = MaterialTheme.typography.bodyLarge)
+                            Text(result.device.address, style = MaterialTheme.typography.bodyMedium)
+                        }
+                    }
                 }
             }
         }
@@ -75,8 +104,10 @@ class MainActivity : ComponentActivity() {
 
     @RequiresPermission(Manifest.permission.BLUETOOTH_SCAN)
     private fun startBleScan() {
+        if (scanning) return
         scannedDevices.clear()
         val scanner = bluetoothAdapter.bluetoothLeScanner
+        scanning = true
         scanCallback = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {
                 val exists = scannedDevices.any { it.device.address == result.device.address }
@@ -87,10 +118,43 @@ class MainActivity : ComponentActivity() {
             }
         }
         scanner.startScan(scanCallback)
+        handler.postDelayed({ stopBleScan() }, 5000)
+    }
+
+    private fun stopBleScan() {
+        scanCallback?.let { bluetoothAdapter.bluetoothLeScanner.stopScan(it) }
+        scanCallback = null
+        scanning = false
+    }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    private fun connectToDevice(device: BluetoothDevice) {
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.BLUETOOTH_CONNECT
+            ) != PackageManager.PERMISSION_GRANTED && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        ) {
+            return
+        }
+        bluetoothGatt?.close()
+        bluetoothGatt = device.connectGatt(this, false, gattCallback)
+    }
+
+    private val gattCallback = object : BluetoothGattCallback() {
+        override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+            if (newState == BluetoothProfile.STATE_CONNECTED) {
+                Log.d(TAG, "GATT connected")
+                gatt.discoverServices()
+            } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                Log.d(TAG, "GATT disconnected")
+                bluetoothGatt = null
+            }
+        }
     }
 
     override fun onDestroy() {
-        scanCallback?.let { bluetoothAdapter.bluetoothLeScanner.stopScan(it) }
+        stopBleScan()
+        bluetoothGatt?.close()
         super.onDestroy()
     }
 }

--- a/platforms/android/app/src/main/java/com/mouse/nearclip/MainActivity.kt
+++ b/platforms/android/app/src/main/java/com/mouse/nearclip/MainActivity.kt
@@ -2,115 +2,95 @@ package com.mouse.nearclip
 
 import android.Manifest
 import android.bluetooth.BluetoothAdapter
-import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothManager
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanResult
 import android.content.Context
-import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
-import android.widget.Button
-import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
 import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
-import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ActivityCompat
-import java.util.UUID
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
 
     private val TAG = "NearClip"
-
     private lateinit var bluetoothAdapter: BluetoothAdapter
-    private var bluetoothGatt: BluetoothGatt? = null
+    private var scanCallback: ScanCallback? = null
+    private val scannedDevices = mutableStateListOf<ScanResult>()
 
-    private var permissionGranted: Boolean = false;
-    // 替换成你的设备信息
-    private val targetDeviceName = "NearClip" // ← 你的 BLE 外设名称
-    private val serviceUUID = UUID.fromString("0000180F-0000-1000-8000-00805f9b34fb") // 电池服务
-    private val characteristicUUID = UUID.fromString("00002A19-0000-1000-8000-00805f9b34fb") // 电池电量
-
-    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    @OptIn(ExperimentalPermissionsApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
-
-        requestPermissionsIfNeeded()
-
-
-
-        findViewById<Button>(R.id.scanButton).setOnClickListener {
-            onClickScanButton()
-        }
-
+        val manager = getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+        bluetoothAdapter = manager.adapter
+        setContent { BleScreen() }
     }
 
-    @RequiresApi(Build.VERSION_CODES.S)
-    private fun onClickScanButton() {
-        val bluetoothLeScanner = bluetoothAdapter.bluetoothLeScanner
+    @OptIn(ExperimentalPermissionsApi::class)
+    @Composable
+    private fun BleScreen() {
+        val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            listOf(
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_CONNECT
+            )
+        } else {
+            listOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+        val permissionState = rememberMultiplePermissionsState(permissions)
 
-        val scanCallback = object : ScanCallback() {
-            @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
-            override fun onScanResult(callbackType: Int, result: ScanResult) {
-                Log.d(TAG, "设备: ${result.device?.name} - ${result.device?.address}")
-
+        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            Button(onClick = {
+                if (permissionState.allPermissionsGranted) {
+                    startBleScan()
+                } else {
+                    permissionState.launchMultiplePermissionRequest()
+                }
+            }) {
+                Text("Scan")
             }
+            LazyColumn(modifier = Modifier.padding(top = 16.dp)) {
+                items(scannedDevices) { result ->
+                    val name = result.device.name ?: "Unknown"
+                    Text("$name - ${result.device.address}")
+                }
+            }
+        }
+    }
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_SCAN)
+    private fun startBleScan() {
+        scannedDevices.clear()
+        val scanner = bluetoothAdapter.bluetoothLeScanner
+        scanCallback = object : ScanCallback() {
+            override fun onScanResult(callbackType: Int, result: ScanResult) {
+                val exists = scannedDevices.any { it.device.address == result.device.address }
+                if (!exists) scannedDevices.add(result)
+            }
             override fun onScanFailed(errorCode: Int) {
                 Log.e(TAG, "扫描失败: $errorCode")
             }
         }
-
-        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
-            // TODO: Consider calling
-            //    ActivityCompat#requestPermissions
-            // here to request the missing permissions, and then overriding
-            //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
-            //                                          int[] grantResults)
-            // to handle the case where the user grants the permission. See the documentation
-            // for ActivityCompat#requestPermissions for more details.
-            return
-        }
-        bluetoothLeScanner.startScan(scanCallback)
+        scanner.startScan(scanCallback)
     }
 
-
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == 1001 && grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
-            val bluetoothManager = getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-            bluetoothAdapter = bluetoothManager.adapter
-            permissionGranted = true;
-        } else {
-            Toast.makeText(this, "需要权限才能使用蓝牙功能", Toast.LENGTH_LONG).show()
-        }
-    }
-
-    private fun requestPermissionsIfNeeded() {
-
-        val requiredPermissions = mutableListOf<String>()
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            requiredPermissions.add(Manifest.permission.BLUETOOTH_SCAN)
-            requiredPermissions.add(Manifest.permission.BLUETOOTH_CONNECT)
-        } else {
-            requiredPermissions.add(Manifest.permission.ACCESS_FINE_LOCATION)
-        }
-
-        val notGranted = requiredPermissions.filter {
-            ActivityCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
-        }
-
-        if (notGranted.isNotEmpty()) {
-            ActivityCompat.requestPermissions(this, notGranted.toTypedArray(), 1001)
-        }
-    }
-
-    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     override fun onDestroy() {
+        scanCallback?.let { bluetoothAdapter.bluetoothLeScanner.stopScan(it) }
         super.onDestroy()
-        bluetoothGatt?.close()
     }
 }


### PR DESCRIPTION
## Summary
- integrate accompanist permissions library
- redesign `MainActivity` with Jetpack Compose
- scan BLE devices when tapping **Scan** button and list results

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883ff3b59488332bb3943167170bf24